### PR TITLE
Remove invalid reference links from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,9 +6,9 @@
 # Datatypes (KEYWORD1)
 #######################################
 MorseCode	KEYWORD1
-pin	KEYWORD1	MorseCode
-freq	KEYWORD1	MorseCode
-unit	KEYWORD1	MorseCode
+pin	KEYWORD1
+freq	KEYWORD1
+unit	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format